### PR TITLE
Refactor to correct echo framework regression error

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/labstack/echo"
 	"github.com/labstack/echo/middleware"
-	"github.com/labstack/echo/engine/standard"
 )
 
 
@@ -86,5 +85,5 @@ func Run() {
 
 
 	fmt.Println("Server now running on port: 1323")
-	e.Run(standard.New(":1323"))
+	e.Logger.Fatal(e.Start(":1323"))
 }


### PR DESCRIPTION
Will need to update the echo framework to for this to work.. maybe delete the current echo framework source and then `go get` (assuming this will work)